### PR TITLE
Adding support for changing offset

### DIFF
--- a/mvision_edr_activity_feed/__main__.py
+++ b/mvision_edr_activity_feed/__main__.py
@@ -127,7 +127,9 @@ def main():
                                       args.password,
                                       verify_cert_bundle=args.cert_bundle),
                      consumer_group=args.consumer_group,
-                     verify_cert_bundle=args.cert_bundle) as channel:
+                     verify_cert_bundle=args.cert_bundle,
+                     offset='latest' if not args.consumer_reset else
+                      'earliest') as channel:
 
             def process_callback(payloads):
                 logging.debug("Received payloads: \n%s",


### PR DESCRIPTION
This PR adds support for reseting a consumer group. When using the `--consumer-reset` flag, the CLI will automatically use `earliest` as the offset (instead of `latest`, which is the default). This is useful for testing purposes, when you want to consume all the events that are available on the backend's buffer.